### PR TITLE
build: 2.0.0-rc0

### DIFF
--- a/docs/chains.md
+++ b/docs/chains.md
@@ -136,26 +136,6 @@ The chain of the example will not be executed until the chain with *id* *CHAIN_O
 }
 ```
 
-In addition, it is possible to set up file system path dependencies in Runnerty with the help of auto-magically configured filewatchers. Them are defined with the **condition** property and can be fired through the following actions:
-
-- *add*: when a file is added.
-- *change*: when a file is changed.
-- *unlink*: when a file is deleted.
-- *error*: when there is an error in the file treatment.
-
-Usage example below:
-
-```json
-{
-  "depends_chains": [
-    {
-      "file_name": "/path/myfile.txt",
-      "condition": "add"
-    }
-  ]
-}
-```
-
 ### Notifications
 
 With the **notifications** property, Runnerty can be set up to emit notifications during the chain status flow, fired up by the following callbacks:

--- a/lib/classes/chain.js
+++ b/lib/classes/chain.js
@@ -4,15 +4,13 @@ const utils = require("../utils.js");
 const dependsProcess = require("../depends-process.js");
 const logger = utils.logger;
 const getProcessByUId = utils.getProcessByUId;
-const checkCalendar = utils.checkCalendar;
-const chokidar = require("chokidar");
 const chronometer = utils.chronometer;
-const schedule = require("node-schedule");
 const crypto = require("crypto");
 const mongoChain = require("../mongodb-models/chain.js");
 
 const Process = require("./process.js");
 const notificationEvent = require("./notificationEvent.js");
+const loadTrigger = utils.loadTrigger;
 
 class Chain {
   constructor(chain) {
@@ -35,30 +33,14 @@ class Chain {
     this.ended_at = chain.ended_at;
     this.processes = {};
 
-    return new Promise((resolve, reject) => {
+    return new Promise(async resolve => {
       let _this = this;
+      await _this.setUid();
+      _this.processes = await _this.loadProcesses(chain.processes);
+      _this.notifications = await _this.loadChainNotifications(chain.notifications);
+      _this.triggers = await _this.loadChainTriggers(chain.triggers);
+      resolve(_this);
 
-      _this.setUid()
-        .then(() => {
-          _this.loadProcesses(chain.processes)
-            .then((processes) => {
-              _this.processes = processes;
-              _this.loadChainNotifications(chain.notifications)
-                .then((notifications) => {
-                  _this.notifications = notifications;
-                  resolve(_this);
-                })
-                .catch((err) => {
-                  reject(err);
-                });
-            })
-            .catch((err) => {
-              reject(err);
-            });
-        })
-        .catch((err) => {
-          reject(`Chain ${_this.id} setUid: ` + err);
-        });
     });
   }
 
@@ -90,10 +72,6 @@ class Chain {
 
           Promise.all(chainProcessPromises)
             .then((processes) => {
-              let processesLength = processes.length;
-              while (processesLength--) {
-                _this.loadProcessFileDependencies(processes[processesLength]);
-              }
               resolve(processes);
             })
             .catch((err) => {
@@ -111,6 +89,45 @@ class Chain {
 
   loadProcess(process) {
     return new Process(process);
+  }
+
+  /**
+   * Load plan chain triggers.
+   * Used in class Chain creation.
+   * @param triggers (plan chain object)
+   * @returns {Promise} Empty
+   */
+  loadChainTriggers(triggers) {
+    let _this = this;
+    return new Promise((resolve, reject) => {
+      let processTriggersPromises = [];
+
+      if (triggers instanceof Array) {
+        let triggersLength = triggers.length;
+        if (triggersLength > 0) {
+          while (triggersLength--) {
+            let trigger = triggers[triggersLength];
+            processTriggersPromises.push(loadTrigger(_this, trigger));
+          }
+
+          Promise.all(processTriggersPromises)
+            .then((triggersArr) => {
+              resolve(triggersArr);
+            })
+            .catch((err) => {
+              //logger.log("error", `Chain ${_this.id} notifications: ` + err);
+              reject(err);
+            });
+
+        } else {
+          logger.log("debug", `Chain ${_this.id} triggers is empty`);
+          resolve();
+        }
+      } else {
+        logger.log("debug", `Chain ${_this.id} triggers is not set`);
+        resolve();
+      }
+    });
   }
 
   /**
@@ -162,59 +179,6 @@ class Chain {
         resolve();
       }
     });
-  }
-
-  loadProcessFileDependencies(process) {
-    let _this = this;
-
-    const depends_process = process.depends_process;
-    let dependsProcessLength = depends_process.length;
-
-    if (dependsProcessLength > 0) {
-      while (dependsProcessLength--) {
-        let dependence = depends_process[dependsProcessLength];
-
-        if (dependence instanceof Object) {
-          if (dependence.hasOwnProperty("file_name") && dependence.hasOwnProperty("condition")) {
-
-            //TODO: VALIDATE CONDITIONS VALUES
-            let watcher = chokidar.watch(dependence.file_name, {
-              ignored: /[/\\](\.|~)/,
-              persistent: true,
-              usePolling: true,
-              awaitWriteFinish: {
-                stabilityThreshold: 2000,
-                pollInterval: 150
-              }
-            });
-
-            watcher.on(dependence.condition, (pathfile) => {
-              if (process.depends_files_ready) {
-                process.depends_files_ready.push(pathfile);
-              } else {
-                process.depends_files_ready = [pathfile];
-              }
-
-              // If chain is running try execute processes:
-              if (_this.isRunning()) {
-                _this.startProcesses()
-                  .then(() => {})
-                  .catch((err) => {
-                    logger.log("error", "Error in loadProcessFileDependencies startProcesses:", err);
-                  });
-              }
-            });
-
-            if (process.file_watchers) {
-              process.file_watchers.push(watcher);
-            } else {
-              process.file_watchers = [watcher];
-            }
-
-          }
-        }
-      }
-    }
   }
 
   getProcessById(processId, _pick) {
@@ -397,51 +361,21 @@ class Chain {
 
       if (_this.hasOwnProperty("processes")) {
         if (_this.processes instanceof Array && _this.processes.length > 0) {
-          // Initialize Chain
-          if (_this.schedule_interval && !options.executeInmediate) {
-            _this.scheduleRepeater = schedule.scheduleJob(_this.schedule_interval, async function () {
-              if ((new Date(_this.end_date)) < (new Date())) {
-                _this.scheduleRepeater.cancel();
-              }
-              let chainCalendarEnable = true;
-              if (_this.calendars) {
-                chainCalendarEnable = await checkCalendar(_this.calendars);
-              }
-              if (chainCalendarEnable) {
-                if (_this.isStopped() || _this.isEnded()) {
-                  _this.setChainToInitState()
-                    .then(() => {
-                      _this.startProcesses(options.waitEndChilds)
-                        .then(() => {
-                          global.runtimePlan.plan.scheduleChains();
-                        })
-                        .catch((err) => {
-                          logger.log("error", "Error in startProcesses:", err);
-                        });
-                    })
-                    .catch((err) => {
-                      logger.log("error", "Error setChainToInitState: ", err);
-                    });
-                } else {
-                  logger.log("debug", `Trying start processes of ${_this.id} but this is running`);
-                }
-              } else {
-                logger.log("debug", `Running chain ${_this.id} disable in calendar`);
-              }
-
-            }.bind(null, _this));
-            resolve();
-
-          } else {
-            _this.startProcesses(options.waitEndChilds)
+          if (options.executeInmediate || options.inputIteration) {
+            _this.run(options)
               .then(() => {
-                global.runtimePlan.plan.scheduleChains();
                 resolve();
               })
-              .catch((err) => {
-                logger.log("error", "Error in startProcesses:", err);
+              .catch(() => {
                 resolve();
               });
+          }else{
+            if(_this.triggers){
+              _this.triggers.forEach(trigger => {
+                trigger.start();
+              });
+            }
+            resolve();
           }
         } else {
           logger.log("error", `Chain ${_this.id} dont have processes`);
@@ -451,6 +385,46 @@ class Chain {
         logger.log("error", `Invalid chain ${_this.id}, processes property not found.`);
         throw new Error(`Invalid chain ${_this.id}, processes property not found.`);
       }
+    });
+  }
+
+  runInitializing(options){
+    let _this = this;
+
+    // If options is not setted, waitEndChilds to true:
+    if(!options){
+      options = {
+        "waitEndChilds": true
+      };
+    }
+
+    if (_this.isStopped() || _this.isEnded()) {
+      _this.setChainToInitState()
+        .then(() => {
+          _this.run(options)
+            .then(() => {})
+            .catch(() => {});
+        })
+        .catch((err) => {
+          logger.log("error", "Error setChainToInitState: ", err);
+        });
+    } else {
+      logger.log("debug", `Trying start processes of ${_this.id} but this is running`);
+    }
+  }
+
+  run(options){
+    let _this = this;
+    return new Promise((resolve) => {
+      _this.startProcesses(options.waitEndChilds)
+        .then(() => {
+          global.runtimePlan.plan.scheduleChains();
+          resolve();
+        })
+        .catch((err) => {
+          logger.log("error", "Error in run (chain):", err);
+          resolve();
+        });
     });
   }
 
@@ -682,7 +656,7 @@ class Chain {
           return _this.startProcess(itemProcess, waitEndChilds)
             .then(() => {})
             .catch((err) => {
-              logger.log("error", "chain startProcesses execSerie  startProcesses waitEndChilds. Error ", err);
+              logger.log("error", "chain startProcesses execSerie startProcesses waitEndChilds. Error ", err);
             });
         });
       });

--- a/lib/classes/execution.js
+++ b/lib/classes/execution.js
@@ -254,7 +254,7 @@ class Execution {
   getConfigValues() {
     let _this = this;
     return new Promise((resolve, reject) =>{
-      _this.process.loadExecutorConfig()
+      _this.chain.loadExecutorConfig()
         .then((configValues) => {
           replaceWithSmart(configValues, _this.process.values())
             .then((res) =>{

--- a/lib/classes/plan.js
+++ b/lib/classes/plan.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const schedule = require("node-schedule");
-const chokidar = require("chokidar");
 const logger = require("../utils.js").logger;
 const pick = require("../utils.js").pick;
 const globToRegExp = require("glob-to-regexp");
@@ -45,10 +43,6 @@ class Plan {
 
           Promise.all(planChainsPromises)
             .then((chains) => {
-              let chainsLength = chains.length;
-              while (chainsLength--) {
-                _this.loadChainFileDependencies(chains[chainsLength]);
-              }
               resolve(chains);
             })
             .catch((err) => {
@@ -69,60 +63,6 @@ class Plan {
 
   loadChain(chain) {
     return new Chain(chain);
-  }
-
-  loadChainFileDependencies(chain) {
-    let _this = this;
-
-    if(chain.depends_chains){
-      const depends_chain = chain.depends_chains;
-      let dependsChainLength = depends_chain.length;
-
-      if (dependsChainLength > 0) {
-        while (dependsChainLength--) {
-          const dependence = depends_chain[dependsChainLength];
-
-          if (dependence instanceof Object) {
-            if (dependence.hasOwnProperty("file_name") && dependence.hasOwnProperty("condition")) {
-
-              let watcher = chokidar.watch(dependence.file_name, {
-                ignored: /[\/\\](\.|\~)/,
-                persistent: true,
-                usePolling: true,
-                awaitWriteFinish: {
-                  stabilityThreshold: 2000,
-                  pollInterval: 150
-                }
-              });
-
-              watcher.on(dependence.condition, (pathfile) => {
-                if (chain.depends_files_ready) {
-                  chain.depends_files_ready.push(pathfile);
-                } else {
-                  chain.depends_files_ready = [pathfile];
-                }
-
-                if (!chain.isRunning() && !chain.isErrored()) {
-                  _this.scheduleChain(chain)
-                    .then(() => {})
-                    .catch((err) => {
-                      logger.log("error", "loadChainFileDependencies scheduleChain", err);
-                    });
-                }
-              });
-
-              if (process.file_watchers) {
-                process.file_watchers.push(watcher);
-              } else {
-                process.file_watchers = [watcher];
-              }
-
-            }
-          }
-        }
-      }
-    }
-
   }
 
   scheduleChains() {
@@ -183,65 +123,51 @@ class Plan {
     }
 
     return new Promise((resolve, reject) => {
-      if ((chain.schedule_interval !== undefined && chain.scheduleRepeater === undefined) || executeInmediate) {
+      if (executeInmediate) {
         chain.stop();
       }
-      if ((!chain.end_date || (chain.hasOwnProperty("end_date") && new Date(chain.end_date) > new Date())) && (chain.isStopped()) && (chain.schedule_interval || executeInmediate)) {
-        if (chain.hasOwnProperty("start_date") || (chain.hasOwnProperty("iterable") || chain.iterable)) {
 
-          logger.log("debug", `SCHEDULED CHAIN ${chain.id} EN ${(new Date(chain.start_date))}`);
+      logger.log("debug", `SCHEDULED CHAIN ${chain.id} - ${(new Date(chain.start_date))}`);
+      logger.log("debug", `start_date: ${(new Date(chain.start_date)) } / now: ${(new Date())}`);
+      logger.log("debug", `TRYING START CHAIN ${chain.id} IN ${(new Date(chain.start_date))}`);
 
-          // Remove Chain from pool
-          if (chain.end_date) {
-            logger.log("debug", `SCHEDULED CHAIN CANCELATION ${chain.id} IN ${(new Date(chain.end_date))}`);
-            chain.scheduleCancel = schedule.scheduleJob(new Date(chain.end_date), function (chain) {
-              logger.log("debug", `CANCELING CHAIN ${chain.id}`);
-              chain.schedule.cancel();
-            }.bind(null, chain));
+      if (!executeInmediate && _this.hasDependenciesBlocking(chain)) {
+        chain.waiting_dependencies();
+        logger.log("debug", `${chain.id} -> on_waiting_dependencies`);
+      } else {
+
+        if (chain.hasOwnProperty("iterable") && chain.iterable && chain.iterable !== "") {
+          if (!inputIterableValues) {
+            const procValues = process.values();
+            const outputIterable = procValues[process.output_iterable];
+
+            if (!outputIterable) {
+              inputIterableValues = _this.getValuesInputIterable(chain);
+            } else {
+              inputIterableValues = outputIterable;
+            }
           }
 
-          if ((new Date(chain.start_date)) <= (new Date()) || (chain.hasOwnProperty("iterable") || chain.iterable)) {
+          let inputIterable = [];
+          if (inputIterableValues && inputIterableValues.length && (inputIterableValues instanceof String)) {
+            try {
+              inputIterable = JSON.parse(inputIterableValues);
+            } catch (err) {
+              reject(`Invalid input (${inputIterableValues}), incorrect JSON` + "\nCaused by: " + err.stack);
+            }
+          }else{
+            if(inputIterableValues instanceof Array){
+              inputIterable = inputIterableValues;
+            }
+          }
 
-            logger.log("debug", `start_date: ${(new Date(chain.start_date)) } / now: ${(new Date())}`);
-            logger.log("debug", `TRYING START CHAIN ${chain.id} IN ${(new Date(chain.start_date))}`);
+          if (inputIterable.length) {
+            const execMode = chain.iterable;
 
-            if (!executeInmediate && _this.hasDependenciesBlocking(chain)) {
-              chain.waiting_dependencies();
-              logger.log("debug", `${chain.id} -> on_waiting_dependencies`);
-            } else {
+            if (execMode === "parallel") {
+              process.childs_chains = [];
 
-              if (chain.hasOwnProperty("iterable") && chain.iterable && chain.iterable !== "") {
-                if (!inputIterableValues) {
-                  const procValues = process.values();
-                  const outputIterable = procValues[process.output_iterable];
-
-                  if (!outputIterable) {
-                    inputIterableValues = _this.getValuesInputIterable(chain);
-                  } else {
-                    inputIterableValues = outputIterable;
-                  }
-                }
-
-                let inputIterable = [];
-                if (inputIterableValues && inputIterableValues.length && (inputIterableValues instanceof String)) {
-                  try {
-                    inputIterable = JSON.parse(inputIterableValues);
-                  } catch (err) {
-                    reject(`Invalid input (${inputIterableValues}), incorrect JSON` + "\nCaused by: " + err.stack);
-                  }
-                }else{
-                  if(inputIterableValues instanceof Array){
-                    inputIterable = inputIterableValues;
-                  }
-                }
-
-                if (inputIterable.length) {
-                  const execMode = chain.iterable;
-
-                  if (execMode === "parallel") {
-                    process.childs_chains = [];
-
-                    createChainSerie(inputIterable)
+              createChainSerie(inputIterable)
                       .then(() => {
                         var chainsToExecLength = process.childs_chains.length;
                         while (chainsToExecLength--) {
@@ -258,11 +184,11 @@ class Plan {
                           });
 
                       });
-                  } else {
+            } else {
                     //SERIE:
-                    process.childs_chains = [];
+              process.childs_chains = [];
 
-                    createChainSerie(inputIterable)
+              createChainSerie(inputIterable)
                       .then(() => {
                         execSerie(process.childs_chains, inputIterable)
                           .then(() => {
@@ -272,19 +198,18 @@ class Plan {
                             reject(err);
                           });
                       });
-                  }
-                } else {
-                  process.stopChildChains();
-                  process.endChildChains();
-                  logger.log("debug", `input not found for iterable process ${process.id}`);
-                  resolve();
-                }
+            }
+          } else {
+            process.stopChildChains();
+            process.endChildChains();
+            logger.log("debug", `input not found for iterable process ${process.id}`);
+            resolve();
+          }
 
-              } else {
-
-                Object.assign(chain.custom_values, customValues);
-                if (customValues && chain.custom_values && Object.keys(chain.custom_values).length !== 0) {
-                  _this.loadChain(chain)
+        } else {
+          Object.assign(chain.custom_values, customValues);
+          if (customValues && chain.custom_values && Object.keys(chain.custom_values).length !== 0) {
+            _this.loadChain(chain)
                     .then((_chain) => {
                       const options = {"executeInmediate": executeInmediate};
                       _chain.start(options)
@@ -298,44 +223,17 @@ class Plan {
                     .catch((err) => {
                       reject(`scheduleChain customsValues loadChain ${chain.id}. Error: ${err}`);
                     });
-                } else {
-                  const options = {"executeInmediate": executeInmediate};
-                  chain.start(options)
+          } else {
+            const options = {"executeInmediate": executeInmediate};
+            chain.start(options)
                     .then(() => {
                       resolve();
                     })
                     .catch((err) => {
                       reject(err);
                     });
-                }
-              }
-            }
-          } else {
-            // Will execute in start_date set
-            chain.schedule = schedule.scheduleJob(new Date(chain.start_date), function (chain) {
-              if (_this.hasDependenciesBlocking(chain)) {
-                chain.waiting_dependencies();
-                logger.log("debug", `${chain.id} -> on_waiting_dependencies`);
-                resolve();
-              } else {
-                logger.log("debug", `${chain.id} -> start`);
-                chain.start()
-                  .then(() => {
-                    resolve();
-                  })
-                  .catch((err) => {
-                    reject(`scheduleChain chain.start Error: ${err}`);
-                  });
-              }
-            }.bind(null, chain));
           }
-
-        } else {
-          reject(`Invalid PlanFile, chain ${chain.id} don´t have start_date.`);
         }
-      } else {
-        logger.log("debug", `CHAIN ${chain.id} IGNORED: END_DATE ${chain.end_date} < CURRENT DATE: `, new Date(), "-  chain.status:" + chain.status, "- chain.schedule_interval:", chain.schedule_interval, "- chain.scheduleRepeater:", (chain.scheduleRepeater === undefined));
-        resolve();
       }
     });
   }
@@ -530,6 +428,7 @@ class Plan {
 
     return res;
   }
+
 
   startChain(chainId, inputValues, customValues){
     let _this = this;

--- a/lib/classes/process.js
+++ b/lib/classes/process.js
@@ -342,7 +342,6 @@ class Process {
       let chainsLength = global.runtimePlan.plan.chains.length;
       let chainsToRun = [];
 
-
       let output_iterable_string = _this.values()[_this.output_iterable];
       let childChainsinputIterable;
 

--- a/lib/classes/trigger.js
+++ b/lib/classes/trigger.js
@@ -1,0 +1,96 @@
+"use strict";
+
+const utils = require("../utils.js");
+const replaceWithSmart = utils.replaceWithSmart;
+const checkCalendar = utils.checkCalendar;
+const logger = utils.logger;
+
+class Trigger {
+  constructor(chain, params) {
+    let _this = this;
+    _this.logger = logger;
+    _this.params = params;
+    _this.chain = chain;
+    return new Promise(resolve => {
+      resolve(_this);
+    });
+  }
+
+  start() {
+    let _this = this;
+    return new Promise((resolve, reject) => {
+      logger.log("error", "Method start (execution) must be rewrite in child class");
+      _this.process.execute_err_return = "Method start (trigger) must be rewrite in child class";
+      _this.process.msg_output = "";
+      _this.process.error();
+      reject("Method start (trigger) must be rewrite in child class");
+    });
+  }
+
+  startChain(checkCalendar = true, inputValues, customValues){
+    return new Promise((resolve, reject) => {
+      let _this = this;
+      let start = false;
+
+      if(customValues){
+       // Object.assign(_this.chain.custom_values || {}, customValues);
+      }
+
+      if(inputValues){
+      //  Object.assign(_this.chain.input || {}, inputValues);
+      }
+
+      if (checkCalendar && _this.params.calendars) {
+        checkCalendar(_this.params.calendars)
+          .then(dateEnableOnDate => {
+            if(dateEnableOnDate){
+              start = true;
+            }else{
+              start = false;
+              logger.log("debug", `Chain ${_this.id} not started: Date not enable in calendar.`);
+              resolve();
+            }
+          })
+          .catch(err => {
+            start = false;
+            logger.log("debug", `Chain ${_this.id} not started - checking calendars: ${err}`);
+            reject(err);
+          });
+      }else{
+        start = true;
+      }
+
+      if(start){
+        _this.chain.runInitializing();
+      }
+    });
+  }
+
+  checkCalendar(calendars, execDate){
+    return checkCalendar(calendars, execDate);
+  }
+
+  logger(type, menssage) {
+    logger.log(type, menssage);
+  }
+
+  getParamValues() {
+    let _this = this;
+    return new Promise((resolve, reject) => {
+      replaceWithSmart(_this.chain.triggers, _this.chain.values())
+        .then((res) => {
+          resolve(res);
+        })
+        .catch((err) => {
+          logger.log("error", "Trigger - Method getParamValues:", err);
+          _this.chain.err_output = "Trigger - Method getParamValues:" + err;
+          _this.chain.msg_output = "";
+          _this.chain.error();
+          reject(err);
+        });
+    });
+  }
+
+}
+
+module.exports = Trigger;

--- a/lib/init.js
+++ b/lib/init.js
@@ -16,6 +16,7 @@ function init(configFilePath, restorePlan, filePlanPath){
     //Global classes:
     global.ExecutionClass = require("./classes/execution.js");
     global.NotificationClass = require("./classes/notification.js");
+    global.TriggerClass = require("./classes/trigger.js");
     global.libUtils = utils;
 
     let config;
@@ -36,7 +37,7 @@ function init(configFilePath, restorePlan, filePlanPath){
           if (config.general.binBackup){
             fileLoad = config.general.binBackup;
             global.planRestored = true;
-            logger.log("warn", `Retoring plan from ${fileLoad}`);
+            logger.log("warn", `Restoring plan from ${fileLoad}`);
           }else{
             logger.log("error", "Restoring: binBackup is not set in config");
             fileLoad = filePlanPath;

--- a/lib/schemas/chain.json
+++ b/lib/schemas/chain.json
@@ -4,15 +4,19 @@
   "properties": {
     "id": {"type": "string"},
     "name": {"type": "string"},
-    "start_date": {"type": "string", "format": "date-time"},
-    "end_date": {"type": "string", "format": "date-time"},
-    "_schedule_interval": {"type": "string", "format": "cron"},
-    "schedule_interval": {"type": "string"},
-    "calendars": {
-      "type": "object",
-      "properties": {
-        "enable":{"type": "string"},
-        "disable":{"type": "string"}
+    "triggers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "calendars": {
+            "type": "object",
+            "properties": {
+              "enable":{"type": "string"},
+              "disable":{"type": "string"}
+            }
+          }
+        }
       }
     },
     "depends_chains": {"type": ["array","object"]},

--- a/lib/schemas/config.json
+++ b/lib/schemas/config.json
@@ -80,6 +80,9 @@
             }
           }
         },
+        "triggers": {
+          "type": "array"
+        },
         "executors": {
           "type": "array"
         },

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -129,7 +129,11 @@ module.exports.loadGeneralConfig = function loadGeneralConfig(configFilePath) {
                 const executorsPath = configLoad.config.general.executorsPath || path.join(path.dirname(configFilePath), "node_modules");
                 const promiseExecutorsSchemas = loadExecutors(executorsPath, configLoad.config.executors);
 
-                Promise.all([promiseNotificatorsSchemas, promiseExecutorsSchemas]).then(() => {
+                // ADD TRIGGERS SCHEMAS:
+                const triggersPath = configLoad.config.general.triggersPath || path.join(path.dirname(configFilePath), "node_modules");
+                const promiseTriggersSchemas = loadTriggers(triggersPath, configLoad.config.triggers);
+
+                Promise.all([promiseNotificatorsSchemas, promiseExecutorsSchemas, promiseTriggersSchemas]).then(() => {
 
                   ajv.addSchema(configSchema, "configSchema");
                   const valid = ajv.validate("configSchema", configLoad);
@@ -154,7 +158,7 @@ module.exports.loadGeneralConfig = function loadGeneralConfig(configFilePath) {
   });
 };
 
-module.exports.loadConfigSection = function loadConfigSection(config, section, id_config) {
+function loadConfigSection(config, section, id_config) {
   return new Promise((resolve, reject) => {
 
     if (config.hasOwnProperty(section)) {
@@ -193,7 +197,9 @@ module.exports.loadConfigSection = function loadConfigSection(config, section, i
       reject(`Section ${section} not found in config file.`, config);
     }
   });
-};
+}
+
+module.exports.loadConfigSection = loadConfigSection;
 
 module.exports.loadSQLFile = function loadSQLFile(filePath) {
   return new Promise((resolve, reject) => {
@@ -739,7 +745,7 @@ module.exports.replaceWithSmart = replaceWithSmart;
 
 function pick(object, allowed){
   let implicitAllowed = [];
-  allowed.forEach(function(item){
+  allowed.forEach(item => {
     let dotPos = item.indexOf(".");
     if(dotPos !== -1){
       implicitAllowed.push(item.substring(0,dotPos));
@@ -1233,6 +1239,83 @@ function loadNotificators(notificatorsPath, notificators) {
 }
 module.exports.loadNotificators = loadNotificators;
 
+function loadTriggers(triggersPath, triggers) {
+  return new Promise((resolve, reject) => {
+    global.triggers = {};
+    requireDir(triggersPath, triggers)
+      .then((res) => {
+        const triggersKeys = Object.keys(res);
+        const triggersLength = triggersKeys.length;
+        if (triggersLength > 0) {
+          let triggersInConfig = {};
+          let items = {};
+          items.anyOf = [];
+          for (let i = 0; i < triggersLength; i++) {
+            let tr = triggersKeys[i];
+            if (res[tr]) {
+              let trSchema = path.join(triggersPath, tr, "schema.json");
+              if (fs.existsSync(trSchema)) {
+                triggersInConfig[tr] = res[tr];
+                let schemaContent = require(trSchema);
+                if(!schemaContent.id) schemaContent.id = tr.replace("\\","-");
+                if(schemaContent.definitions.config && !schemaContent.definitions.config.id) schemaContent.definitions.config.id = tr + "#/definitions/config";
+                items.anyOf.push({"$ref": tr + "#/definitions/config"});
+                ajv.addSchema(schemaContent, tr);
+
+                if (!ajv.getSchema("trigger_" + tr)) {
+                  ajv.addSchema(schemaContent.definitions.params, "trigger_" + tr);
+                }
+
+              } else {
+                logger.log("error", `Schema not found in trigger ${tr}`);
+              }
+            } else {
+              logger.log("error", `Trigger type ${tr} in config not found in triggers path: ${triggersPath}`);
+            }
+          }
+          configSchema.properties.config.properties.triggers.items = items;
+          global.triggers = triggersInConfig;
+        }
+        resolve();
+      })
+      .catch((err) => {
+        reject(err);
+      });
+  });
+}
+module.exports.loadTriggers = loadTriggers;
+
+function loadTriggerConfig(id) {
+  return loadConfigSection(global.config, "triggers", id);
+}
+
+function loadTrigger(chain, triggerParams) {
+  let res = {};
+
+  return new Promise((resolve, reject) => {
+    loadTriggerConfig(triggerParams.id)
+      .then((configValues) => {
+        if (!triggerParams.type && configValues.type) {
+          triggerParams.type = configValues.type;
+        }
+        triggerParams.config = configValues;
+
+        checkTriggersParams(triggerParams)
+          .then(async () => {
+            res = await new global.triggers[configValues.type](chain, triggerParams);
+            resolve(res);
+          })
+          .catch((err) => {
+            reject(err);
+          });
+      })
+      .catch(err => {
+        reject(err);
+      });
+  });
+}
+module.exports.loadTrigger = loadTrigger;
+
 function checkExecutorParams(executor) {
   return new Promise((resolve, reject) => {
     const executorId = executor.type;
@@ -1278,6 +1361,29 @@ function checkNotificatorParams(notification) {
   });
 }
 module.exports.checkNotificatorParams = checkNotificatorParams;
+
+function checkTriggersParams(trigger) {
+  return new Promise((resolve, reject) => {
+    const triggerId = trigger.type;
+
+    if (ajv.getSchema("trigger_" + triggerId)) {
+      let valid = false;
+      try{
+        valid = ajv.validate("trigger_" + triggerId, trigger);
+        if(valid){
+          resolve();
+        }else{
+          reject(ajv.errors);
+        }
+      }catch(err){
+        reject(`Trigger params: ${err}`);
+      }
+    } else {
+      reject(`Schema of params not found in trigger ${triggerId}`);
+    }
+  });
+}
+module.exports.checkTriggersParams = checkTriggersParams;
 
 function loadWSAPI() {
   return new Promise(resolve => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "runnerty",
   "description": "Process orchestrator",
-  "version": "1.0.4",
+  "version": "2.0.0-rc0",
   "preferGlobal": true,
   "main": "index.js",
   "license": "MIT",
@@ -27,7 +27,6 @@
     "ajv": "^5.2.2",
     "body-parser": "^1.17.2",
     "bytes": "^3.0.0",
-    "chokidar": "^1.7.0",
     "commander": "^2.11.0",
     "express": "^4.15.4",
     "express-jwt": "^5.3.0",
@@ -40,7 +39,6 @@
     "moment": "^2.18.1",
     "mongoose": "^4.11.10",
     "morgan": "^1.8.2",
-    "node-schedule": "^1.2.4",
     "object-sizeof": "^1.2.0",
     "redis": "^2.8.0",
     "winston": "^2.3.1"

--- a/samples/config.json
+++ b/samples/config.json
@@ -59,6 +59,12 @@
       "options": {}
     }
   },
+  "triggers": [
+    {
+      "id":"schedule_default",
+      "type":"@runnerty-trigger-schedule"
+    }
+    ],
   "executors": [
     {
       "id":"scp_default",

--- a/samples/plan_standard.json
+++ b/samples/plan_standard.json
@@ -3,10 +3,15 @@
     {
       "id":"CHAIN_ONE",
       "name":"Chain one sample",
-      "start_date":"2017-04-01T00:00:00.00Z",
-      "end_date":"2099-11-01T00:00:00.00Z",
-      "schedule_interval":"*/1 * * * *",
       "depends_chains":[],
+      "triggers":[
+        {
+          "id":"schedule_dafault",
+          "start_date":"2017-04-01T00:00:00.00Z",
+          "end_date":"2099-11-01T00:00:00.00Z",
+          "schedule_interval":"*/1 * * * *"
+        }
+      ],
       "notifications":{
         "on_start":[
           {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/Coderty/runnerty/blob/master/CONTRIGUTING.md#commit
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
A chain execution happens (is provoked) by the schdeule_interval of the chain. 

**What is the new behavior?**
Now the execution happens by a trigger (npm) that could be developed and enganged to Runnerty. E.g. trigger-schedule and trigger-file-watcher


**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:
Triggers have been included in this version (2.0.0). Now, shcedule happens to be a trigger (npm: @runnerty/trigger-schedule). Therefore, all the schedule fields ("start_date", "end_date": y "schedule_interval") should be removed from the plan/chains. 

To start a chain we should use triggers:

Example:
**Before**
In the plan:
```json
{
  "id":"CHAIN_ONE",
  "name":"Chain one sample",
  "start_date":"2017-04-01T00:00:00.00Z",
  "end_date":"2099-11-01T00:00:00.00Z",
  "schedule_interval":"*/1 * * * *",
  "...":"..."
}
```
**Now**
In the plan:
```json
{
  "id":"CHAIN_ONE",
  "name":"Chain one sample",
  "triggers":[
    {
     "id":"schedule_dafault",
     "start_date":"2017-06-18T00:00:00.00Z",
     "end_date":"2099-06-18T00:00:00.00Z",
     "schedule_interval":"*/1 * * * *"
    }
  ],
  "...":"..."
}
```
In the config:
```json
{
  "...":"...",
  "triggers": [
    {
      "id":"schedule_default",
      "type":"@runnerty-trigger-schedule"
    }
  ],
  "...":"..."
}
```
**Other examples:**
Combine several triggers for the same chain:
```json
{
  "...":"...",
  "triggers":[
      {
        "id":"schedule_default",
        "start_date":"2017-04-01T00:00:00.00Z",
        "end_date":"2099-11-01T00:00:00.00Z",
        "schedule_interval":"*/1 * * * *"
      },
      {
        "id":"filewatcher_default",
        "file_name": "/etc/runnerty/myfile.txt",
        "condition": "add"
      }
    ],
  "...":"..."
}
```


**Other information**: