### PR TITLE
fix: getNodeModulesPath win compatibility

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const fsp = require('fs').promises;
+const os = require('os');
 const path = require('path');
 const helmet = require('helmet');
 const sizeof = require('object-sizeof');
@@ -108,7 +109,8 @@ function getNodeModulesPath(initialPath) {
   if (fs.existsSync(initialPath)) {
     return initialPath;
   } else {
-    if (initialPath === '/node_modules') {
+    const rootModules = path.resolve(os.platform == 'win32' ? process.cwd().split(path.sep)[0] : '/', '/node_modules');
+    if (initialPath === rootModules) {
       return false;
     } else {
       const previousDir = path.resolve(initialPath, '..', '..', 'node_modules');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit message follows our guidelines: https://github.com/Coderty/runnerty/blob/master/CONTRIGUTING.md#commit
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/runnerty/runnerty/blob/master/lib/utils.js#L107-L118

The root path comparison does not work on win32 platform

```js
if (initialPath === '/node_modules') {
``` 
`C:\\node_modules` is not comparable to `/node_modules` which procudes


```
C:\Users\estar\Workspace\coderty\core\runnerty-example\test_runnerty_local_telemetry  (runnerty-quick-start@2.0.0)
λ runnerty.cmd
{
  previousDir: 'C:\\Users\\estar\\Workspace\\coderty\\core\\runnerty-example\\node_modules'
}
{
  previousDir: 'C:\\Users\\estar\\Workspace\\coderty\\core\\node_modules'
}
{ previousDir: 'C:\\Users\\estar\\Workspace\\coderty\\node_modules' }
{ previousDir: 'C:\\Users\\estar\\Workspace\\node_modules' }
{ previousDir: 'C:\\Users\\estar\\node_modules' }
{ previousDir: 'C:\\Users\\node_modules' }
{ previousDir: 'C:\\node_modules' }
{ previousDir: 'C:\\node_modules' }
{ previousDir: 'C:\\node_modules' }
{ previousDir: 'C:\\node_modules' }
{ previousDir: 'C:\\node_modules' }
{ previousDir: 'C:\\node_modules' }
{ previousDir: 'C:\\node_modules' }
{ previousDir: 'C:\\node_modules' }
{ previousDir: 'C:\\node_modules' }
{ previousDir: 'C:\\node_modules' }
{ previousDir: 'C:\\node_modules' }
{ previousDir: 'C:\\node_modules' }
{ previousDir: 'C:\\node_modules' }
{ previousDir: 'C:\\node_modules' }
...
...
error: Error in runnerty init. Error: Loading general config: RangeError: Maximum call stack size exceeded.
error: Loading general config: RangeError: Maximum call stack size exceeded.
```

**What is the new behavior?**
Same as intended on UNIX-based systems, but considering the drive root path in win32 platform

```
C:\Users\estar\Workspace\coderty\core\runnerty-example\test_runnerty_local_telemetry  (runnerty-quick-start@2.0.0)
λ node ..\runnerty\index.js
{
  previousDir: 'C:\\Users\\estar\\Workspace\\coderty\\core\\runnerty-example\\node_modules'
}
{
  previousDir: 'C:\\Users\\estar\\Workspace\\coderty\\core\\node_modules'
}
{ previousDir: 'C:\\Users\\estar\\Workspace\\coderty\\node_modules' }
{ previousDir: 'C:\\Users\\estar\\Workspace\\node_modules' }
{ previousDir: 'C:\\Users\\estar\\node_modules' }
{ previousDir: 'C:\\Users\\node_modules' }
{ previousDir: 'C:\\node_modules' }
error: Error in runnerty init. Error: Loading general config: Error: node_modules not found C:\Users\estar\Workspace\coderty\core\runnerty-example\test_runnerty_local_telemetry\node_modules. This problem is usually solved by installing the dependencies with npm install.
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
